### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,7 +38,7 @@ class ItemsController < ApplicationController
     item = Item.find(params[:id])
     if item.destroy
       redirect_to root_path
-    else 
+    else
       render :show
     end
   end
@@ -53,7 +53,7 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-  
+
   def contributor_confiramation
     redirect_to root_path unless current_user == @item.user
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :contributor_confiramation, only: [:edit, :update]
 
   def index
@@ -32,6 +32,10 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @item.destroy
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
   before_action :set_item, only: [:show, :edit, :update]
-  before_action :contributor_confiramation, only: [:edit, :update]
+  before_action :contributor_confiramation, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order('created_at DESC')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :contributor_confiramation, only: [:edit, :update]
 
   def index
@@ -35,7 +35,12 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
+    item = Item.find(params[:id])
+    if item.destroy
+      redirect_to root_path
+    else 
+      render :show
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :contributor_confiramation, only: [:edit, :update, :destroy]
 
   def index
@@ -35,8 +35,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    if item.destroy
+    if @item.destroy
       redirect_to root_path
     else
       render :show

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,8 +28,8 @@
       <% if current_user.id == @item.user.id %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-      <% else  %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
+      <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
# What
詳細画面から商品の出品者のみが商品を削除できるように機能を追加
そのまま詳細画面に止まると、削除されたidを探してエラーが発生するので、
削除後はトップページに遷移するように設定。

# Why
出品の取り消しを行うため。
また、削除のエラーを回避するため。

# 動作確認動画
1. ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
- https://gyazo.com/edc7957de9a30f958faf606769597431